### PR TITLE
Prune transaction

### DIFF
--- a/monero/backends/jsonrpc/daemon.py
+++ b/monero/backends/jsonrpc/daemon.py
@@ -141,7 +141,8 @@ class JSONRPCDaemon(object):
     def _do_get_transactions(self, hashes):
         res = self.raw_request('/get_transactions', {
                 'txs_hashes': hashes,
-                'decode_as_json': True})
+                'decode_as_json': True,
+                'prune': True})
         if res['status'] != 'OK':
             raise exceptions.BackendException(res['status'])
         txs = []

--- a/monero/backends/jsonrpc/daemon.py
+++ b/monero/backends/jsonrpc/daemon.py
@@ -126,7 +126,7 @@ class JSONRPCDaemon(object):
             return Block(**data)
         raise exceptions.BackendException(res['status'])
 
-    def transactions(self, hashes):
+    def transactions(self, hashes, prune=False):
         """
         Returns a list of transactions for given hashes. Automatically chunks the request
         into amounts acceptable by a restricted RPC server.
@@ -134,15 +134,15 @@ class JSONRPCDaemon(object):
         hashes = list(hashes)
         result = []
         while len(hashes):
-            result.extend(self._do_get_transactions(hashes[:RESTRICTED_MAX_TRANSACTIONS]))
+            result.extend(self._do_get_transactions(hashes[:RESTRICTED_MAX_TRANSACTIONS], prune=prune))
             hashes = hashes[RESTRICTED_MAX_TRANSACTIONS:]
         return result
 
-    def _do_get_transactions(self, hashes):
+    def _do_get_transactions(self, hashes, prune):
         res = self.raw_request('/get_transactions', {
                 'txs_hashes': hashes,
                 'decode_as_json': True,
-                'prune': True})
+                'prune': prune})
         if res['status'] != 'OK':
             raise exceptions.BackendException(res['status'])
         txs = []

--- a/monero/daemon.py
+++ b/monero/daemon.py
@@ -78,12 +78,13 @@ class Daemon(object):
             raise ValueError("Height or hash must be specified")
         return self._backend.block(bhash=bhash, height=height)
 
-    def transactions(self, hashes):
+    def transactions(self, hashes, prune=False):
         """
         Returns transactions matching given hashes. Accepts single hash or a sequence.
 
-        :hashes: str or list of str
+        :param hashes: str or list of str
+        :param bool prune: prune option for /get_transactions, defaults to False
         """
         if isinstance(hashes, six.string_types):
             hashes = [hashes]
-        return self._backend.transactions(hashes)
+        return self._backend.transactions(hashes, prune=prune)


### PR DESCRIPTION
I changed one file: `monero.backends.jsonrpc.daemon` to add one line.
This send the `"prune": True` option along with the `get_transactions` call.
The data that is pruned is not used by the `_do_get_transactions` call but
it can save up to 80% in bandwidth.