### PR TITLE
wallet: pass computed _backend rather than default

### DIFF
--- a/monero/wallet.py
+++ b/monero/wallet.py
@@ -36,8 +36,8 @@ class Wallet(object):
             raise ValueError('backend already given, other arguments are extraneous')
 
         self._backend = backend if backend else JSONRPCWallet(**kwargs)
-        self.incoming = PaymentManager(0, backend, 'in')
-        self.outgoing = PaymentManager(0, backend, 'out')
+        self.incoming = PaymentManager(0, self._backend, 'in')
+        self.outgoing = PaymentManager(0, self._backend, 'out')
         self.refresh()
 
     def refresh(self):


### PR DESCRIPTION
Fixes #88 


```
>>> from monero.wallet import Wallet
>>> w = Wallet(user='test', password='xxxxx', port=55013)
>>> w.incoming()
[in: fee8572047997cd7475db25bda66e4a5877f2ca8d57601508f52b4ea1c77d358 @ 751843 0.079916580000 id=0000000000000000, in: 005efc36f8eeba1911b6b071f030f9cbdd4003a8c94bbddd24ca9d98be9525a1 @ 751046 0.069916390000 id=0000000000000000, in: 78b9b2bd18dbb226440bb6cfdf12c7f8fcd1fd8d1e .......]
```