### PR TITLE
Fixed Daemon.block bug for height=0

### DIFF
--- a/monero/daemon.py
+++ b/monero/daemon.py
@@ -74,7 +74,7 @@ class Daemon(object):
 
         :rtype: :class:`Block <monero.block.Block>`
         """
-        if not height and not bhash:
+        if height is None and bhash is None:
             raise ValueError("Height or hash must be specified")
         return self._backend.block(bhash=bhash, height=height)
 


### PR DESCRIPTION
If you called daemon.block(height=0) then the expression:

    if not height and not bhash:

Is `True` because 0 is falsey. I changed that line to a slightly more wordy, but more accurate:

    if height is None and bhash is None: