### PR TITLE
Fix output_indices bug

### DIFF
--- a/monero/backends/jsonrpc/daemon.py
+++ b/monero/backends/jsonrpc/daemon.py
@@ -163,7 +163,7 @@ class JSONRPCDaemon(object):
                 timestamp=datetime.fromtimestamp(
                     tx['block_timestamp']) if 'block_timestamp' in tx else None,
                 blob=binascii.unhexlify(tx['as_hex']) or None,
-                output_indices=None if tx['in_pool'] else tx['output_indices'],
+                output_indices=tx['output_indices'] if ('output_indices' in tx) else None,
                 json=as_json))
         return txs
 


### PR DESCRIPTION
When I wrote the output code, I made the assumption that if a transaction
was not in the transaction pool then its "output_indices" atrribute would
be present. However, upon further testing I found that for transactions
with 0 outputs, such as at height 202612, the Monero daemon returns a JSON
object with no "output_indices" attribute. This PR should keep a KeyError
from occurring.