### PR TITLE
Unlock pynacl versions to allow for v1.5 and higher (but less than v2)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pycryptodomex~=3.10
-pynacl~=1.4.0
+pynacl~=1.4
 requests
 six>=1.12.0
 ipaddress


### PR DESCRIPTION
`~=1.4.0` allows for 1.4.X, but not 1.5.0. `~=1.4` will allow for versions 1.4 and greater, but less than version 2.