### PR TITLE
Update transactions.rst

### DIFF
--- a/docs/source/transactions.rst
+++ b/docs/source/transactions.rst
@@ -152,7 +152,7 @@ them the transactions they do not have.
 
     **With significant amounts you should also wait for a few confirmations to appear.** The top
     of the blockchain sometimes gets replaced by a competing block. It is a popular practice to
-    wait for at least 6 confirmations to appear, which is also the standard in Monero before funds
+    wait for at least 10 confirmations to appear, which is also the standard in Monero before funds
     get unlocked and can be used in subsequent transactions.
 
 However, it is possible to query the wallet for transactions in the mempool. You may use them as


### PR DESCRIPTION
Transacted funds get locked for 10 blocks.
I would simply change the 6 to a 10 because with significant amounts it still is the practice to wait for 10 confirmations.